### PR TITLE
Fix use after free bug in environment_free

### DIFF
--- a/ext/lmdb_ext/lmdb_ext.h
+++ b/ext/lmdb_ext/lmdb_ext.h
@@ -60,6 +60,7 @@ typedef struct {
         MDB_env* env;
         VALUE    thread_txn_hash;
         VALUE    txn_thread_hash;
+        int      txn_count;
 } Environment;
 
 typedef struct {


### PR DESCRIPTION
There is a use-after-free bug in `environment_free` that can cause a segmentation fault in the lmdb gem.

The problem is that `environment_free` is checking the size of the `environment->txn_thread_hash` Hash. However, by the time `environment_free` is called to free the `Environment` instance, `txn_thread_hash` (as well as `thread_tsx_hash`) may have already been freed by the garbage collector (and the `VALUE` may have subsequently been reused for another object).

My solution was to add a counter member to the `Environment` class that I think should accomplish the goal of detecting if there are any outstanding transactions in order to print a warning in the finalizer. Perhaps it would be better to just remove the warning altogether?
