### PR TITLE
Use https URL for submodule instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor"]
 	path = vendor
-	url = git@github.com:LMDB/lmdb.git
+	url = https://github.com/LMDB/lmdb.git


### PR DESCRIPTION
Avoids ssh auth errors when installing on a system without GitHub ssh access.