### PR TITLE
Add Environment#databases method to list names of named databases

### DIFF
--- a/ext/lmdb_ext/lmdb_ext.h
+++ b/ext/lmdb_ext/lmdb_ext.h
@@ -156,6 +156,7 @@ static VALUE environment_clear_flags(int argc, VALUE* argv, VALUE self);
 static VALUE environment_close(VALUE self);
 static VALUE environment_copy(VALUE self, VALUE path);
 static VALUE environment_database(int argc, VALUE *argv, VALUE self);
+static VALUE environment_databases(VALUE self);
 static VALUE environment_flags(VALUE self);
 static void environment_free(Environment *environment);
 static VALUE environment_info(VALUE self);

--- a/spec/lmdb_spec.rb
+++ b/spec/lmdb_spec.rb
@@ -100,6 +100,27 @@ describe LMDB do
       subject.flags.should_not include(:nosync)
     end
 
+    describe 'databases' do
+      it 'returns empty list when there are no named databases' do
+        subject.databases.should == []
+      end
+
+      it 'returns list of named databases' do
+        db1 = subject.database 'db1', create: true
+        db2 = subject.database 'db2', create: true
+        subject.databases.should == ['db1', 'db2']
+      end
+
+      it 'returns list of named databases when there are non-database kes in the main db' do
+        main = subject.database
+        main['key'] = 'value'
+        subject.database 'db1', create: true
+        subject.database 'db2', create: true
+
+        subject.databases.should == ['db1', 'db2']
+      end
+    end
+
     describe LMDB::Transaction do
       subject { env }
 


### PR DESCRIPTION
Uses the same database discovery mechanism as `mdb_dump`. 

Trying to do this in plain ruby is expensive because opening a non existing database raises. 